### PR TITLE
preserve redirect_uri for token access

### DIFF
--- a/EOAuth2Service.php
+++ b/EOAuth2Service.php
@@ -97,7 +97,7 @@ abstract class EOAuth2Service extends EAuthServiceBase implements IAuthService {
 	 * @return string url to request.
 	 */
 	protected function getTokenUrl($code) {
-		return $this->providerOptions['access_token'].'?client_id='.$this->client_id.'&client_secret='.$this->client_secret.'&code='.$code.'&redirect_uri='.urlencode($this->getState('redirect_uri'));;
+		return $this->providerOptions['access_token'].'?client_id='.$this->client_id.'&client_secret='.$this->client_secret.'&code='.$code.'&redirect_uri='.urlencode($this->getState('redirect_uri'));
 	}
 
 	/**


### PR DESCRIPTION
Подробности тут: http://habrahabr.ru/post/150756/

Основной смысл в том, что redirect_uri нужно проталкивать и в запрос токена, имея код.
В проекте такой функционал уже реализован для Фейсбука, имхо его надо вытащить в базовый OAuth2 класс.

Плюс проблема, описанная в https://github.com/Nodge/yii-eauth/pull/22 связана именно с этим — для зарегистрированных до этого фикса приложений ВК отдает токен, одновременно говоря:
- если redirect_uri нет, то "надо указать redirect_uri"
- если redirect_uri есть, но не совпадает, то "redirect_uri не совпадает, не стоит логинить этого человека"

Если redirect_uri есть в запросе токена и он правильный — поля error, описанного в указанном пулл-реквесте — нет.
