### PR TITLE
fix: facebook oauth

### DIFF
--- a/services/FacebookOAuthService.php
+++ b/services/FacebookOAuthService.php
@@ -70,8 +70,7 @@ class FacebookOAuthService extends EOAuth2Service {
 
 	protected function getAccessToken($code) {
 		$response = $this->makeRequest($this->getTokenUrl($code), array(), false);
-		parse_str($response, $result);
-		return $result;
+		return json_decode($response, true);
 	}
 
 	/**


### PR DESCRIPTION
facebook oauth response is json object. so the code is breaking at line 83.
parse_str is replaced with json_decode